### PR TITLE
lets-hike/3 refactor how parks are rendered by activity

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "add": "^2.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router": "^6.8.2",
+    "react-router-dom": "^6.8.2",
     "react-scripts": "5.0.1",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0",

--- a/src/api/nationalParkService.ts
+++ b/src/api/nationalParkService.ts
@@ -1,6 +1,7 @@
 import {
   Activity,
   NationalParkServiceActivityResponse,
+  NationalParkServiceParkAmenitiesResponse,
   NationalParkServiceParkResponse,
 } from "../model/nationalParkServiceResponse";
 
@@ -45,9 +46,29 @@ const getParksByActivity = (
   });
 };
 
+const getAmenitiesByParkCode = (
+  parkCode: string
+): Promise<NationalParkServiceParkAmenitiesResponse> => {
+  const endpoint = `${BASE_API_URL}/amenities/parksplaces?parkCode=${parkCode}&api_key=${API_KEY}`;
+  const requestInfo = {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    fetch(endpoint, requestInfo).then((response) => {
+      if (!response.ok) reject(response.status);
+      resolve(response.json());
+    }, reject);
+  });
+};
+
 const NationalParkServicesAPI = {
-  getParksByActivity,
   getActivityCategories,
+  getAmenitiesByParkCode,
+  getParksByActivity,
 };
 
 export default NationalParkServicesAPI;

--- a/src/components/homePage/ActivitySelectionComponent.tsx
+++ b/src/components/homePage/ActivitySelectionComponent.tsx
@@ -23,6 +23,7 @@ const ActivitySelectionComponent: FC<ActivitySelectionType> = ({
       <Select
         fullWidth
         name={name}
+        size="small"
         id="activity-input"
         value={selectedActivity}
         onChange={(activity) =>

--- a/src/components/homePage/ActivitySelectionComponent.tsx
+++ b/src/components/homePage/ActivitySelectionComponent.tsx
@@ -1,7 +1,7 @@
 import { InputLabel, MenuItem, Select } from "@mui/material";
 import { Box } from "@mui/system";
 import { FC, useState } from "react";
-import { Activity } from "../model/nationalParkServiceResponse";
+import { Activity } from "../../model/nationalParkServiceResponse";
 
 type ActivitySelectionType = {
   name: string;

--- a/src/components/homePage/CommonParkComponent.tsx
+++ b/src/components/homePage/CommonParkComponent.tsx
@@ -1,18 +1,21 @@
+import { FC } from "react";
 import {
+  Button,
   Card,
+  CardActions,
   CardContent,
   CardHeader,
-  Link,
   Typography,
 } from "@mui/material";
-import { FC } from "react";
-import { Park } from "../model/nationalParkServiceResponse";
+import { useNavigate } from "react-router";
+import { Park } from "../../model/nationalParkServiceResponse";
 
 type CommonParkType = {
   park: Park;
 };
 
 const CommonParkComponent: FC<CommonParkType> = ({ park }) => {
+  const navigate = useNavigate();
   const { states, parkCode, designation, fullName, url, name } = park;
 
   return (
@@ -25,12 +28,12 @@ const CommonParkComponent: FC<CommonParkType> = ({ park }) => {
         <Typography variant="body2">
           National park code: {parkCode}
         </Typography>
-        <Link href={url}>
-          <Typography variant="subtitle1">
-            More information can be found here
-          </Typography>
-        </Link>
       </CardContent>
+      <CardActions>
+        <Button onClick={() => navigate(`/park/${parkCode}`)}>
+          Learn More
+        </Button>
+      </CardActions>
     </Card>
   );
 };

--- a/src/components/homePage/CommonParkComponent.tsx
+++ b/src/components/homePage/CommonParkComponent.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useNavigate } from "react-router";
-import { Park } from "../../model/nationalParkServiceResponse";
+import { ParkBase as Park } from "../../model/nationalParkServiceResponse";
 
 type CommonParkType = {
   park: Park;
@@ -30,7 +30,9 @@ const CommonParkComponent: FC<CommonParkType> = ({ park }) => {
         </Typography>
       </CardContent>
       <CardActions>
-        <Button onClick={() => navigate(`/park/${parkCode}`)}>
+        <Button
+          onClick={() => navigate(`/park?parkCode=${parkCode}`)}
+        >
           Learn More
         </Button>
       </CardActions>

--- a/src/components/homePage/HomePage.tsx
+++ b/src/components/homePage/HomePage.tsx
@@ -7,12 +7,12 @@ import {
   Paper,
   Typography,
 } from "@mui/material";
-import NationalParkServicesAPI from "../api/nationalParkService";
+import NationalParkServicesAPI from "../../api/nationalParkService";
 import {
   Activity,
   NationalParkServiceActivityResponse,
   NationalParkServiceParkResponse,
-} from "../model/nationalParkServiceResponse";
+} from "../../model/nationalParkServiceResponse";
 import ActivitySelectionComponent from "./ActivitySelectionComponent";
 import NationalParkListComponent from "./NationalParkListComponent";
 

--- a/src/components/homePage/NationalParkListComponent.tsx
+++ b/src/components/homePage/NationalParkListComponent.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { CircularProgress, Grid } from "@mui/material";
 import { NationalParkServiceParkResponse } from "../../model/nationalParkServiceResponse";
-import CommonParkComponent from "./CommonParkComponent";
+import ParkActivityComponent from "./ParkActivityComponent";
 
 type NationalParkListType = {
   isLoaded: boolean;
@@ -27,18 +27,12 @@ const NationalParkListComponent: FC<NationalParkListType> = ({
       {isLoaded ? (
         <>
           {/* using first index here only because we are getting one result currently, this does need to change though */}
-          {parkResponse?.data[0].parks.map((park) => {
-            return (
-              <Grid
-                item
-                key={park.parkCode}
-                xs={4}
-                sx={{ mr: 2, mt: 3 }}
-              >
-                <CommonParkComponent park={park} />
-              </Grid>
-            );
-          })}
+          {parkResponse?.data.map((pr) => (
+            <ParkActivityComponent 
+              key={pr.id}
+              parkActivityResponse={pr}
+            />
+          ))}
         </>
       ) : (
         <CircularProgress />

--- a/src/components/homePage/NationalParkListComponent.tsx
+++ b/src/components/homePage/NationalParkListComponent.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { CircularProgress, Grid } from "@mui/material";
-import { NationalParkServiceParkResponse } from "../model/nationalParkServiceResponse";
+import { NationalParkServiceParkResponse } from "../../model/nationalParkServiceResponse";
 import CommonParkComponent from "./CommonParkComponent";
 
 type NationalParkListType = {
@@ -26,7 +26,12 @@ const NationalParkListComponent: FC<NationalParkListType> = ({
           {/* using first index here only because we are getting one result currently, this does need to change though */}
           {parkResponse?.data[0].parks.map((park) => {
             return (
-              <Grid item xs={4} sx={{ mr: 2, mt: 3 }}>
+              <Grid
+                item
+                key={park.parkCode}
+                xs={4}
+                sx={{ mr: 2, mt: 3 }}
+              >
                 <CommonParkComponent park={park} />
               </Grid>
             );

--- a/src/components/homePage/NationalParkListComponent.tsx
+++ b/src/components/homePage/NationalParkListComponent.tsx
@@ -8,6 +8,9 @@ type NationalParkListType = {
   parkResponse?: NationalParkServiceParkResponse;
 };
 
+// Left off here: issue with my typing, TS doesn't think "parks" exists in the "ParkResponse" type
+// "parks" does in fact exist on the "ParkResponse" type, so something weird happening
+
 const NationalParkListComponent: FC<NationalParkListType> = ({
   isLoaded,
   parkResponse,

--- a/src/components/homePage/ParkActivityComponent.tsx
+++ b/src/components/homePage/ParkActivityComponent.tsx
@@ -1,0 +1,35 @@
+import { Grid } from "@mui/material";
+import { FC } from "react";
+import { ParkResponse } from "../../model/nationalParkServiceResponse";
+import CommonParkComponent from "./CommonParkComponent";
+
+
+type ParkActivityType = {
+  parkActivityResponse: ParkResponse;
+};
+
+// possibly use this component as a section for each activity
+// so display the activity name and seperate each of these components by activity name??
+
+const ParkActivityComponent: FC<ParkActivityType> = ({
+  parkActivityResponse
+}) => {
+  const activityParks = parkActivityResponse.parks;
+
+  return (
+    <>
+      {activityParks.map((park) => (
+        <Grid
+          item
+          key={park.parkCode}
+          xs={4}
+          sx={{ mr: 2, mt: 3 }}
+        >
+          <CommonParkComponent park={park} />
+        </Grid>
+      ))}
+    </>
+  );
+};
+
+export default ParkActivityComponent;

--- a/src/components/homePage/index.tsx
+++ b/src/components/homePage/index.tsx
@@ -1,0 +1,5 @@
+// not currently working
+
+import HomePage from "./HomePage";
+
+export default { HomePage };

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,6 @@
+// not currently working
+
+import HomePage from "./homePage";
+import ParkPage from "./parkPage";
+
+export default { HomePage, ParkPage };

--- a/src/components/parkPage/ParkPage.tsx
+++ b/src/components/parkPage/ParkPage.tsx
@@ -1,0 +1,9 @@
+import { FC } from "react";
+
+type ParkPageProps = {};
+
+const ParkPage: FC<ParkPageProps> = (props) => {
+  return <>Under Construction</>;
+};
+
+export default ParkPage;

--- a/src/components/parkPage/ParkPage.tsx
+++ b/src/components/parkPage/ParkPage.tsx
@@ -1,8 +1,16 @@
-import { FC } from "react";
+import { FC, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 
-type ParkPageProps = {};
+const ParkPage: FC<unknown> = () => {
+  const [searchParams] = useSearchParams();
 
-const ParkPage: FC<ParkPageProps> = (props) => {
+  useEffect(() => {
+    const parkCode = searchParams.get("parkCode");
+    if (parkCode) {
+      console.log(`Park code sent from home page: ${parkCode}`);
+    }
+  }, []);
+
   return <>Under Construction</>;
 };
 

--- a/src/components/parkPage/index.tsx
+++ b/src/components/parkPage/index.tsx
@@ -1,0 +1,5 @@
+// not currently working
+
+import ParkPage from "./ParkPage";
+
+export default { ParkPage };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import HomePage from "./components/HomePage";
+import { RouterProvider } from "react-router-dom";
 import reportWebVitals from "./reportWebVitals";
+import routes from "./routes";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <HomePage />
+    <RouterProvider router={routes} />
   </React.StrictMode>
 );
 

--- a/src/model/nationalParkServiceResponse.ts
+++ b/src/model/nationalParkServiceResponse.ts
@@ -4,6 +4,20 @@ type NationaParkBaseResponse = {
   start: string;
 };
 
+type ParkResponseBase = {
+  id: string;
+  name: string;
+};
+
+export type ParkBase = {
+  states: string;
+  parkCode: string;
+  designation: string;
+  fullName: string;
+  url: string;
+  name: string;
+};
+
 /********************************************
  *          Activity Response Models        *
  ********************************************/
@@ -22,19 +36,8 @@ export type NationalParkServiceActivityResponse = {
  *          Park Response Models            *
  ********************************************/
 
-export type Park = {
-  states: string;
-  parkCode: string;
-  designation: string;
-  fullName: string;
-  url: string;
-  name: string;
-};
-
-export type ParkResponse = {
-  id: string; // activity id
-  name: string; // activity name
-  parks: Array<Park>;
+export type ParkResponse = ParkResponseBase & {
+  parks: Array<ParkBase>;
 };
 
 // an array of ParkResponse is returned, meaning it can return multiple ParkResponse's
@@ -42,4 +45,29 @@ export type ParkResponse = {
 export type NationalParkServiceParkResponse = {
   base: NationaParkBaseResponse;
   data: Array<ParkResponse>;
+};
+
+/********************************************
+ *      Park Amenities Response Models      *
+ ********************************************/
+
+export type NationalParkServiceParkAmenitiesResponse = {
+  base: NationaParkBaseResponse;
+  data: Array<ParkAmenities>;
+};
+
+type ParkAmenities = {
+  id: string;
+  name: string;
+  parks: Array<ParkAmenitiesResponse>;
+};
+
+type ParkAmenitiesResponse = ParkBase & {
+  places: Array<ParkPlaces>;
+};
+
+export type ParkPlaces = {
+  title: string;
+  id: string;
+  url: string;
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,16 @@
+import { createBrowserRouter } from "react-router-dom";
+import HomePage from "../components/homePage/HomePage";
+import ParkPage from "../components/parkPage/ParkPage";
+
+const routes = createBrowserRouter([
+  {
+    path: "/",
+    element: <HomePage />,
+  },
+  {
+    path: "/park/:parkId",
+    element: <ParkPage />,
+  },
+]);
+
+export default routes;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,7 +8,7 @@ const routes = createBrowserRouter([
     element: <HomePage />,
   },
   {
-    path: "/park/:parkId",
+    path: "/park",
     element: <ParkPage />,
   },
 ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1777,6 +1777,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
+"@remix-run/router@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.3.tgz#d6d531d69c0fa3a44fda7dc00b20d49b44549164"
+  integrity sha512-YRHie1yQEj0kqqCTCJEfHqYSSNlZQ696QJG+MMiW4mxSl9I0ojz/eRhJS4fs88Z5i6D1SmoF9d3K99/QOhI8/w==
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -7750,6 +7755,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.8.2:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.8.2.tgz#a6654a3400be9aafd504d7125573568921b78b57"
+  integrity sha512-N/oAF1Shd7g4tWy+75IIufCGsHBqT74tnzHQhbiUTYILYF0Blk65cg+HPZqwC+6SqEyx033nKqU7by38v3lBZg==
+  dependencies:
+    "@remix-run/router" "1.3.3"
+    react-router "6.8.2"
+
+react-router@6.8.2, react-router@^6.8.2:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.8.2.tgz#98f83582a73f316a3287118b440f0cee30ed6f33"
+  integrity sha512-lF7S0UmXI5Pd8bmHvMdPKI4u4S5McxmHnzJhrYi9ZQ6wE+DA8JN5BzVC5EEBuduWWDaiJ8u6YhVOCmThBli+rw==
+  dependencies:
+    "@remix-run/router" "1.3.3"
 
 react-scripts@5.0.1:
   version "5.0.1"


### PR DESCRIPTION
This PR allows for rendering up multiple activities and the parks related to those activities selected. Currently I'm only allowing the selection of one activity at a time which will return an array of length 1 which holds an array of related parks.

But this same API call can be made with multiple activities selected, now if multiple activities are selected they can be rendered properly. This does however still need work, I want to have each activity section display the name of the activity and be a little more separated so it's easier to read and gives a better UX.